### PR TITLE
Replace 3.10-stretch with 3.11-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-stretch
+FROM python:3.11-bullseye
 
 COPY . /usr/src/app/
 


### PR DESCRIPTION
`stretch` does not exist anymore in the official Python docker repo, so bullseye is used instead.

Also, switching to 3.11, as that is fully supported by this library.